### PR TITLE
Small fixes for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.6-alpine
 ENV PYTHONUNBUFFERED 1
 RUN apk update && apk add build-base python-dev libffi-dev postgresql-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine
 ENV PYTHONUNBUFFERED 1
-RUN apk update && apk add build-base python-dev libffi-dev postgresql-dev
+RUN apk update && apk add build-base libffi-dev postgresql-dev
 
 RUN mkdir -p /opt/app
 COPY requirements/prod.txt /opt/app/requirements.txt

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.6-alpine
 ENV PYTHONUNBUFFERED 1
 RUN apk update && apk add build-base python-dev libffi-dev postgresql-dev
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine
 ENV PYTHONUNBUFFERED 1
-RUN apk update && apk add build-base python-dev libffi-dev postgresql-dev
+RUN apk update && apk add build-base libffi-dev postgresql-dev
 
 RUN mkdir -p /opt/app
 COPY requirements/dev.txt /opt/app/requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       POSTGRES_DB: chaospizza
   app:
     image: chaospizza-build
+    build:
+        context: .
+        dockerfile: Dockerfile.build
     depends_on:
       - db
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: postgres:9.6
+    image: postgres:9.6-alpine
     volumes:
       - ./build/db:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
I was trying to start chaospizza on my laptop and it failed.

The root of the problem was that the used Python version was `3-alpine` which currently is 3.7. But some of our dependencies don't support 3.7 - at least in the versions we use.
So I changed this to `3.6-alpine` which works.

I also made a few other minor changes to the build.